### PR TITLE
feat(BUILD-4676): use cirrus-modules@master

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/SonarSource/cirrus-modules@v2", "load_features")
+load("github.com/SonarSource/cirrus-modules@master", "load_features")
 
 def main(ctx):
   return load_features(ctx, only_if=dict())

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,6 @@ container_definition: &CONTAINER_DEFINITION
   cluster_name: ${CIRRUS_CLUSTER_NAME}
   region: eu-central-1
   namespace: default
-  builder_subnet_ids: ${CIRRUS_AWS_SUBNETS}
   builder_role: cirrus-builder
   builder_image: docker-builder-v*
   builder_instance_type: t3.small


### PR DESCRIPTION
The first commit tests the backward compliance.
The second commit uses the default subnet filtering.