### PR TITLE
BUILD-8605 Include mise version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ jobs:
     name: "pre-commit"
     runs-on: ubuntu-24.04-large
     steps:
-      - uses: 'jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4' # v2.3.1
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           version: 2025.7.12
       - uses: SonarSource/gh-action_pre-commit@3d5b503c1ce51d0f92665875b9bea716eff1e70f # 1.0.7

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,16 +2,17 @@
 on:
   pull_request:
   merge_group:
-
 jobs:
   pre-commit:
     name: "pre-commit"
     runs-on: ubuntu-24.04-large
     steps:
-      - uses: jdx/mise-action@5cb1df66ed5e1fb3c670ea0b62fd17a76979826a # v2.3.1
+      - uses: 'jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4' # v2.3.1
+        with:
+          version: 2025.7.12
       - uses: SonarSource/gh-action_pre-commit@3d5b503c1ce51d0f92665875b9bea716eff1e70f # 1.0.7
         with:
           extra-args: >
-            --from-ref=origin/${{ github.event.pull_request.base.ref }}
-            --to-ref=${{ github.event.pull_request.head.sha }}
+            --from-ref=origin/${{ github.event.pull_request.base.ref }} --to-ref=${{ github.event.pull_request.head.sha }}
+
           ignore-failure: ${{ github.event_name == 'merge_group' }}


### PR DESCRIPTION
BUILD-8605
This PR updates `jdx/mise-action` to a pinned version and configures the `mise` version to `2025.7.12`.