### PR TITLE
BUILD-8764 remove get-build-number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: SonarSource/ci-github-actions/get-build-number@master # dogfood
       - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
         with:
           sonar-platform: sqc-eu
@@ -38,7 +37,6 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: SonarSource/ci-github-actions/get-build-number@master # dogfood
       - uses: SonarSource/ci-github-actions/promote@master # dogfood
         with:
           promote-pull-request: true


### PR DESCRIPTION
[BUILD-8764](https://sonarsource.atlassian.net/browse/BUILD-8764)

Remove get-build-number as its now included in the build-* actions.

[BUILD-8764]: https://sonarsource.atlassian.net/browse/BUILD-8764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ