### PR TITLE
BUILD-9431 Test grouped GitHub Actions logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: SonarSource/ci-github-actions/build-poetry@e50fb05 # dogfood
+      - uses: SonarSource/ci-github-actions/build-poetry@BUILD-9431-group-action-logs-readability # dogfood
         with:
           sonar-platform: sqc-eu
           deploy-pull-request: true
@@ -39,6 +39,6 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: SonarSource/ci-github-actions/promote@e50fb05 # dogfood
+      - uses: SonarSource/ci-github-actions/promote@BUILD-9431-group-action-logs-readability # dogfood
         with:
           promote-pull-request: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: SonarSource/ci-github-actions/build-poetry@BUILD-9431-group-action-logs-readability # dogfood
+      - uses: SonarSource/ci-github-actions/build-poetry@e50fb05 # dogfood
         with:
           sonar-platform: sqc-eu
           deploy-pull-request: true
@@ -39,6 +39,6 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: SonarSource/ci-github-actions/promote@BUILD-9431-group-action-logs-readability # dogfood
+      - uses: SonarSource/ci-github-actions/promote@e50fb05 # dogfood
         with:
           promote-pull-request: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
+      - uses: SonarSource/ci-github-actions/build-poetry@BUILD-9431-group-action-logs-readability # dogfood
         with:
           sonar-platform: sqc-eu
           deploy-pull-request: true
@@ -39,6 +39,6 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: SonarSource/ci-github-actions/promote@master # dogfood
+      - uses: SonarSource/ci-github-actions/promote@BUILD-9431-group-action-logs-readability # dogfood
         with:
           promote-pull-request: true


### PR DESCRIPTION
## Summary
- Points ci-github-actions references to the `BUILD-9431-group-action-logs-readability` branch to test grouped log output
- This is a temporary test PR — do not merge

## Actions being tested
- `build-poetry`
- `promote`