### PR TITLE
Test BUILD-10215: standardize GitHub Actions output logging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
+      - uses: SonarSource/ci-github-actions/build-poetry@BUILD-10215-standardize-ghaction-output-logging # dogfood
         with:
           sonar-platform: sqc-eu
           deploy-pull-request: true
@@ -39,6 +39,6 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: SonarSource/ci-github-actions/promote@master # dogfood
+      - uses: SonarSource/ci-github-actions/promote@BUILD-10215-standardize-ghaction-output-logging # dogfood
         with:
           promote-pull-request: true


### PR DESCRIPTION
## Summary
- Point ci-github-actions references to `BUILD-10215-standardize-ghaction-output-logging` branch for testing
- Tests the standardization of GitHub Actions output logging (::error and ::warning annotations)

## Test plan
- [ ] Verify build workflow runs successfully
- [ ] Check that error/warning annotations appear correctly in the GitHub Actions UI

> **Note**: This is a temporary test PR. Revert to `@master` after testing.


🤖 Generated with [Claude Code](https://claude.com/claude-code)