### PR TITLE
BUILD-10590 retrigger verified approvals on review events

### DIFF
--- a/.github/workflows/re-trigger-approvals.yml
+++ b/.github/workflows/re-trigger-approvals.yml
@@ -1,0 +1,17 @@
+---
+name: Re-trigger Approvals
+on:
+  pull_request_review:
+    types: [submitted, dismissed]
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: Head SHA of the pull request to re-trigger approvals for
+        required: true
+        type: string
+
+jobs:
+  re-trigger:
+    uses: SonarSource/ci-github-actions/.github/workflows/re-trigger-approvals.yml@feat/jcarsique/BUILD-10590-verifiedApprovals
+    with:
+      head_sha: ${{ github.event.pull_request.head.sha || inputs.head_sha }}


### PR DESCRIPTION
## Summary

Part of [BUILD-10590](https://sonarsource.atlassian.net/browse/BUILD-10590) — PoC GitHub org rule workflow to secure PRs.

Adds a workflow that re-triggers the `verified-approvals` check whenever a pull request review is submitted or dismissed.
This ensures the approval count is re-evaluated after any review activity, keeping the GitHub ruleset check accurate.

Depends on https://github.com/SonarSource/ci-github-actions/pull/227
Need to be merged first, for testing purposes. Then it will be realigned on master: https://github.com/SonarSource/sonar-dummy-python-oss/pull/88

## Changes

- Add `.github/workflows/re-trigger-approvals.yml`: triggers on `pull_request_review` (submitted/dismissed) and delegates to the reusable workflow [`SonarSource/ci-github-actions/.github/workflows/re-trigger-approvals.yml`](https://github.com/SonarSource/ci-github-actions/blob/feat/jcarsique/BUILD-10590-verifiedApprovals/.github/workflows/re-trigger-approvals.yml).

## Context

The GitHub org ruleset [#4485920](https://github.com/organizations/SonarSource/settings/rules/4485920) ("2 approvers for public repositories") requires the `verified-approvals` workflow to pass before merging.
This workflow enforces that:
- internal PRs have at least **1 approval**
- external PRs have at least **2 approvals**

This repository (`sonar-dummy-python-oss`) is used as the test bed for the feature.

## Test plan

- [ ] Open a PR and verify the `verified-approvals` check is triggered on review submission
- [ ] Dismiss a review and verify the check is re-triggered
- [ ] Confirm check passes with the required number of approvals for internal and external PRs

[BUILD-10590]: https://sonarsource.atlassian.net/browse/BUILD-10590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ