### PR TITLE
BUILD-10590 The nested job 're-trigger' requests 'actions: write'

### DIFF
--- a/.github/workflows/re-trigger-approvals.yml
+++ b/.github/workflows/re-trigger-approvals.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   re-trigger:
+    permissions:
+      actions: write
     uses: SonarSource/ci-github-actions/.github/workflows/re-trigger-approvals.yml@feat/jcarsique/BUILD-10590-verifiedApprovals
     with:
       head_sha: ${{ github.event.pull_request.head.sha || inputs.head_sha }}


### PR DESCRIPTION
Fix 
```
The workflow is not valid. .github/workflows/re-trigger-approvals.yml (Line: 14, Col: 3): Error calling workflow 'SonarSource/ci-github-actions/.github/workflows/re-trigger-approvals.yml@feat/jcarsique/BUILD-10590-verifiedApprovals'. 
The nested job 're-trigger' is requesting 'actions: write', but is only allowed 'actions: none'.
```