### PR TITLE
test: BUILD-10591 dogfood feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
+      - uses: SonarSource/ci-github-actions/build-poetry@feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary # dogfood
         with:
           sonar-platform: sqc-eu
           deploy-pull-request: true
@@ -39,6 +39,6 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: SonarSource/ci-github-actions/promote@master # dogfood
+      - uses: SonarSource/ci-github-actions/promote@feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary # dogfood
         with:
           promote-pull-request: true

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -10,4 +10,4 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: SonarSource/ci-github-actions/pr_cleanup@master # dogfood
+      - uses: SonarSource/ci-github-actions/pr_cleanup@feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary # dogfood

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
+      - uses: SonarSource/ci-github-actions/build-poetry@feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary # dogfood
         with:
           run-shadow-scans: true
 


### PR DESCRIPTION
## Summary

- Dogfooding `feat/jcarsique/BUILD-10591-setup-jfrog-cli-summary` from `SonarSource/ci-github-actions`
- Tests the JFrog Job Summary feature enabled by `jfrog/setup-jfrog-cli` in all build actions

## Test plan

- [ ] Verify JFrog Job Summary appears in the GitHub Actions workflow summary
- [ ] Confirm build and deployment works as before

**DO NOT MERGE** — testing branch only