### PR TITLE
BUILD-10765 Update gh-action_release to v6.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@feat/tom/BUILD-7998
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@7b055eca5ce771ff254fbec2697c0fc1c7207e1e # 6.4.0
     with:
       publishToPyPI: ${{ !github.event.release.prerelease }} # Only publish to PyPI for non-prerelease releases
       publishToTestPyPI: ${{ github.event.release.prerelease }}


### PR DESCRIPTION
## Summary
- Update `gh-action_release` to v6.4.0 (`7b055eca5ce771ff254fbec2697c0fc1c7207e1e`)

## Test plan
- [ ] Verify release workflow runs successfully