### PR TITLE
Add StepSecurity Harden Runner to workflows

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -17,6 +17,9 @@ jobs:
     if: |
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - id: secrets
         uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # 3.2.0
         with:

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -16,6 +16,9 @@ jobs:
     if: |
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - id: secrets
         uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # 3.2.0
         with:

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -16,6 +16,9 @@ jobs:
     if: |
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - id: secrets
         uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # 3.2.0
         with:

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -19,6 +19,9 @@ jobs:
       && (github.event.review.state == 'changes_requested'
           || github.event.review.state == 'approved')
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - id: secrets
         uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # 3.2.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
       contents: write
       attestations: write
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
         with:
@@ -39,6 +42,9 @@ jobs:
       id-token: write
       contents: write
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: SonarSource/ci-github-actions/promote@master # dogfood
         with:
           promote-pull-request: true

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -10,4 +10,7 @@ jobs:
     permissions:
       actions: write
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: SonarSource/ci-github-actions/pr_cleanup@master # dogfood

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,9 @@ jobs:
     name: "pre-commit"
     runs-on: github-ubuntu-latest-s
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           version: 2025.12.13

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -12,6 +12,9 @@ jobs:
   notify:
     runs-on: github-ubuntu-latest-s
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - name: Send Slack Notification
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -13,6 +13,9 @@ jobs:
       id-token: write
       contents: write
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
         with:


### PR DESCRIPTION
Adds [`step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40`](https://github.com/step-security/harden-runner) (v2.19.0) as the first step in every job across all workflow files, using `egress-policy: audit` to monitor outbound network traffic without blocking.

**Workflows updated:** `build.yml`, `pre-commit.yml`, `pr-cleanup.yml`, `slack_notify.yml`, `unified-dogfooding.yml`, `PullRequestClosed.yml`, `PullRequestCreated.yml`, `RequestReview.yml`, `SubmitReview.yml`

> `release.yml` is excluded as its job uses a reusable workflow call (`uses:`) and does not support injecting steps.