### PR TITLE
BUILD-11264 chore: upgrade gh-action_release to v7 (master)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
         description: 'Release version'
         required: true
         type: string
+      publishToTestPyPI:
+        description: 'Publish to Test PyPI instead of PyPI'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   release:
@@ -16,6 +21,7 @@ jobs:
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@master # dogfood
     with:
       version: ${{ inputs.version }}
-      publishToPyPI: true
+      publishToPyPI: ${{ !inputs.publishToTestPyPI }}
+      publishToTestPyPI: ${{ inputs.publishToTestPyPI }}
       skipPythonReleasabilityChecks: true
       isDummyProject: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,21 @@
 name: Release
+# yamllint disable-line rule:truthy
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        type: string
 
 jobs:
   release:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@master # dogfood
     with:
-      publishToPyPI: ${{ !github.event.release.prerelease }} # Only publish to PyPI for non-prerelease releases
-      publishToTestPyPI: ${{ github.event.release.prerelease }}
+      version: ${{ inputs.version }}
+      publishToPyPI: true
       skipPythonReleasabilityChecks: true
       isDummyProject: true


### PR DESCRIPTION
Part of BUILD-11249.

## Changes
- Migrate trigger from `release: published` to `workflow_dispatch` with `version` input
- Upgrade `gh-action_release` reference to `@master` (v7 dogfood)
- Add `isDummyProject: true`