### PR TITLE
BUILD-8956 Verify config-poetry action

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,4 @@
 self-hosted-runner:
   labels:
     - github-ubuntu-latest-s
+    - warp-custom-ubuntu-24-04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Verify Poetry resolves dependencies via Repox
         shell: bash -leo pipefail {0}
         run: |
+          cat ~/.bashrc
+          which poetry
           poetry install && poetry build
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,6 @@ jobs:
       contents: write
       attestations: write
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - id: build-poetry
         uses: SonarSource/ci-github-actions/build-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
@@ -63,9 +60,6 @@ jobs:
     env:
       BUILD_NUMBER: ${{ needs.build.outputs.BUILD_NUMBER }}
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: audit
       - uses: SonarSource/ci-github-actions/promote@master # dogfood
         with:
           promote-pull-request: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Verify Poetry resolves dependencies via Repox
         shell: bash -leo pipefail {0}
         run: |
-          cat ~/.bashrc
-          which poetry
+          echo "127.0.0.1 pypi.org" >> /etc/hosts
           poetry install && poetry build
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  verify-config-poetry:
+    runs-on: warp-custom-ubuntu-24-04
+    name: Verify config-poetry
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: SonarSource/ci-github-actions/config-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
+      - name: Verify Poetry resolves dependencies via Repox
+        run: |
+          export PATH="$PATH:/home/runner/.local/bin"
+          poetry install && poetry build
+
   build:
     outputs:
-      BUILD_NUMBER: ${{ steps.config-poetry.outputs.BUILD_NUMBER }}
+      BUILD_NUMBER: ${{ steps.build-poetry.outputs.BUILD_NUMBER }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Build
     permissions:
       id-token: write
@@ -26,12 +40,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          version: 2026.5.9
-      - id: config-poetry
-        uses: SonarSource/ci-github-actions/config-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
-      - uses: SonarSource/ci-github-actions/build-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
+      - id: build-poetry
+        uses: SonarSource/ci-github-actions/build-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
         with:
           sonar-platform: sqc-eu
           deploy-pull-request: true
@@ -43,7 +53,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Promote
     permissions:
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,24 +9,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  verify-config-poetry:
-    runs-on: github-ubuntu-latest-s
-    name: Verify config-poetry
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: audit
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          version: 2026.5.9
-      - uses: SonarSource/ci-github-actions/config-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
-      - name: Verify Poetry resolves dependencies via Repox
-        run: poetry install && poetry build
-
   build:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -42,6 +24,10 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.5.9
+      - uses: SonarSource/ci-github-actions/config-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
       - uses: SonarSource/ci-github-actions/build-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
         with:
           sonar-platform: sqc-eu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  verify-config-poetry:
+  config:
     runs-on: warp-custom-ubuntu-24-04
     name: Verify config-poetry
     permissions:
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: SonarSource/ci-github-actions/config-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
       - name: Verify Poetry resolves dependencies via Repox
+        shell: bash -leo pipefail {0}
         run: |
-          export PATH="$PATH:/home/runner/.local/bin"
           poetry install && poetry build
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Verify Poetry resolves dependencies via Repox
         shell: bash -leo pipefail {0}
         run: |
-          echo "127.0.0.1 pypi.org" >> /etc/hosts
+          sudo sh -c 'echo "127.0.0.1 pypi.org" >> /etc/hosts'
           poetry install && poetry build
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    outputs:
+      BUILD_NUMBER: ${{ steps.config-poetry.outputs.BUILD_NUMBER }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
@@ -27,7 +29,8 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.9
-      - uses: SonarSource/ci-github-actions/config-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
+      - id: config-poetry
+        uses: SonarSource/ci-github-actions/config-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
       - uses: SonarSource/ci-github-actions/build-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
         with:
           sonar-platform: sqc-eu
@@ -45,6 +48,8 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    env:
+      BUILD_NUMBER: ${{ needs.build.outputs.BUILD_NUMBER }}
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  verify-config-poetry:
+    runs-on: github-ubuntu-latest-s
+    name: Verify config-poetry
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.5.9
+      - uses: SonarSource/ci-github-actions/config-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
+      - name: Verify Poetry resolves dependencies via Repox
+        run: poetry install && poetry build
+
   build:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -24,7 +42,7 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
+      - uses: SonarSource/ci-github-actions/build-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
         with:
           sonar-platform: sqc-eu
           deploy-pull-request: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,12 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    outputs:
+      BUILD_NUMBER: ${{ steps.config-poetry.outputs.BUILD_NUMBER }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: SonarSource/ci-github-actions/config-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
+        id: config-poetry
       - name: Verify Poetry resolves dependencies via Repox
         shell: bash -leo pipefail {0}
         run: |
@@ -26,8 +29,7 @@ jobs:
           poetry install && poetry build
 
   build:
-    outputs:
-      BUILD_NUMBER: ${{ steps.build-poetry.outputs.BUILD_NUMBER }}
+    needs: config
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
@@ -37,10 +39,11 @@ jobs:
       id-token: write
       contents: write
       attestations: write
+    env:
+      BUILD_NUMBER: ${{ needs.config.outputs.BUILD_NUMBER }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - id: build-poetry
-        uses: SonarSource/ci-github-actions/build-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
+      - uses: SonarSource/ci-github-actions/build-poetry@feat/hnasr/BUILD-8956-createConfigPoetry # dogfood
         with:
           sonar-platform: sqc-eu
           deploy-pull-request: true
@@ -49,6 +52,7 @@ jobs:
   promote:
     needs:
       - build
+      - config
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
@@ -58,7 +62,7 @@ jobs:
       id-token: write
       contents: write
     env:
-      BUILD_NUMBER: ${{ needs.build.outputs.BUILD_NUMBER }}
+      BUILD_NUMBER: ${{ needs.config.outputs.BUILD_NUMBER }}
     steps:
       - uses: SonarSource/ci-github-actions/promote@master # dogfood
         with:


### PR DESCRIPTION
## Summary

Dogfood PR to validate the new `config-poetry` action from [SonarSource/ci-github-actions#292](https://github.com/SonarSource/ci-github-actions/pull/292).

- Adds a **Verify config-poetry** job that runs the standalone action, then `poetry install` and `poetry build`
- Points **build-poetry** at `feat/hnasr/BUILD-8956-createConfigPoetry` for end-to-end validation through the refactored build action

## Test plan

- [ ] `Verify config-poetry` job passes (standalone action + Poetry install/build via Repox)
- [ ] `Build` job passes (build-poetry consuming config-poetry internally)
- [ ] `Promote` job passes

Revert action refs to `@master` / `@v1` after ci-github-actions#292 is merged.

----
## Summary by Gitar

- **Runner configuration:**
  - Updated `runs-on` targets to use `warp-custom-ubuntu-24-04` for all workflows.
  - Added `warp-custom-ubuntu-24-04` as an allowed label in `.github/actionlint.yaml`.
- **CI Workflow enhancements:**
  - Configured `build` job to output `BUILD_NUMBER` and passed it to the `promote` job via environment variables.


<sub>This will update automatically on new commits.</sub>