### PR TITLE
BUILD-12327 Route Python installs through Repox

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
-      - uses: SonarSource/ci-github-actions/config-poetry@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
       - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
         with:
           sonar-platform: sqc-eu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
+      - uses: SonarSource/ci-github-actions/config-pip@v1
       - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
         with:
           sonar-platform: sqc-eu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
+      - uses: SonarSource/ci-github-actions/config-poetry@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
       - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
         with:
           sonar-platform: sqc-eu

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
+      - uses: SonarSource/ci-github-actions/config-pip@v1
       - name: Export pip index for isolated hook venvs
         run: |
           index_url="$(python3 -c 'import configparser, pathlib; c = configparser.ConfigParser(); c.read(pathlib.Path.home() / ".pip" / "pip.conf"); print(c["global"]["index-url"])')"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,6 +20,7 @@ jobs:
           index_url="$(python3 -c 'import configparser, pathlib; c = configparser.ConfigParser(); c.read(pathlib.Path.home() / ".pip" / "pip.conf"); print(c["global"]["index-url"])')"
           echo "::add-mask::${index_url}"
           echo "PIP_INDEX_URL=${index_url}" >> "$GITHUB_ENV"
+          echo "VIRTUALENV_INDEX_URL=${index_url}" >> "$GITHUB_ENV"
           echo "PIP_TRUSTED_HOST=repox.jfrog.io" >> "$GITHUB_ENV"
       - uses: SonarSource/ci-github-actions/config-npm@master # dogfood
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,9 +19,11 @@ jobs:
         run: |
           index_url="$(python3 -c 'import configparser, pathlib; c = configparser.ConfigParser(); c.read(pathlib.Path.home() / ".pip" / "pip.conf"); print(c["global"]["index-url"])')"
           echo "::add-mask::${index_url}"
-          echo "PIP_INDEX_URL=${index_url}" >> "$GITHUB_ENV"
-          echo "VIRTUALENV_INDEX_URL=${index_url}" >> "$GITHUB_ENV"
-          echo "PIP_TRUSTED_HOST=repox.jfrog.io" >> "$GITHUB_ENV"
+          {
+            echo "PIP_INDEX_URL=${index_url}"
+            echo "VIRTUALENV_INDEX_URL=${index_url}"
+            echo "PIP_TRUSTED_HOST=repox.jfrog.io"
+          } >> "$GITHUB_ENV"
       - uses: SonarSource/ci-github-actions/config-npm@master # dogfood
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,8 +15,6 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
-        with:
-          disable-caching: true
       - uses: SonarSource/ci-github-actions/config-npm@master # dogfood
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,6 +22,10 @@ jobs:
           {
             echo "PIP_INDEX_URL=${index_url}"
             echo "VIRTUALENV_INDEX_URL=${index_url}"
+            echo "VIRTUALENV_PIP=embed"
+            echo "VIRTUALENV_SETUPTOOLS=embed"
+            echo "VIRTUALENV_WHEEL=embed"
+            echo "VIRTUALENV_DOWNLOAD=false"
             echo "PIP_TRUSTED_HOST=repox.jfrog.io"
           } >> "$GITHUB_ENV"
       - uses: SonarSource/ci-github-actions/config-npm@master # dogfood

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,10 +6,18 @@ jobs:
   pre-commit:
     name: "pre-commit"
     runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
+        with:
+          disable-caching: true
+      - uses: SonarSource/ci-github-actions/config-npm@master # dogfood
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           version: 2025.12.13

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,12 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
+      - name: Export pip index for isolated hook venvs
+        run: |
+          index_url="$(python3 -c 'import configparser, pathlib; c = configparser.ConfigParser(); c.read(pathlib.Path.home() / ".pip" / "pip.conf"); print(c["global"]["index-url"])')"
+          echo "::add-mask::${index_url}"
+          echo "PIP_INDEX_URL=${index_url}" >> "$GITHUB_ENV"
+          echo "PIP_TRUSTED_HOST=repox.jfrog.io" >> "$GITHUB_ENV"
       - uses: SonarSource/ci-github-actions/config-npm@master # dogfood
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-      - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
+      - uses: SonarSource/ci-github-actions/config-pip@v1
       - name: Send Slack Notification
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
+      - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
+        with:
+          disable-caching: true
       - name: Send Slack Notification
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -16,8 +16,6 @@ jobs:
         with:
           egress-policy: audit
       - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
-        with:
-          disable-caching: true
       - name: Send Slack Notification
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
       - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
         with:
           run-shadow-scans: true

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
+      - uses: SonarSource/ci-github-actions/config-poetry@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
       - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
         with:
           run-shadow-scans: true

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -18,7 +18,6 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: SonarSource/ci-github-actions/config-pip@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
-      - uses: SonarSource/ci-github-actions/config-poetry@3c6565f5a65282d333ab60c8a0fa733c09e613d3 # 1.8.7
       - uses: SonarSource/ci-github-actions/build-poetry@master # dogfood
         with:
           run-shadow-scans: true


### PR DESCRIPTION
## Summary
- Configure pip before the Poetry build so Python package installs use Repox instead of PyPI
- Configure pip (and npm for Node-based hooks) before mise and pre-commit
- Configure pip before Slack notify so its Python installs use Repox
- Ticket: [BUILD-12327](https://sonarsource.atlassian.net/browse/BUILD-12327)

## Test plan
- [x] Build workflow is green on this PR
- [x] Pre-commit workflow is green on this PR
- [x] Job logs show pip/Poetry traffic to `repox.jfrog.io`, not `pypi.org` / `files.pythonhosted.org`

## Evidence
- Build: https://github.com/SonarSource/sonar-dummy-python-oss/actions/runs/32376935863
- Pre-commit: https://github.com/SonarSource/sonar-dummy-python-oss/actions/runs/32376935991
- Build log: `Looking in indexes: ***repox.jfrog.io/artifactory/api/pypi/sonarsource-pypi/simple`
- Build log: `Downloading https://repox.jfrog.io/artifactory/api/pypi/sonarsource-pypi/pysonar/...`

[BUILD-12327]: https://sonarsource.atlassian.net/browse/BUILD-12327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ